### PR TITLE
feat: add arm64 support and use a non-root path

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,27 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        arch: [amd64, arm64]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run Setup Coder Action
+        uses: ./
+        with:
+          access_url: ${{ secrets.CODER_URL }}
+          coder_session_token: ${{ secrets.CODER_SESSION_TOKEN }}
+
+      - name: Run Coder CLI
+        run: coder whoami

--- a/action.yaml
+++ b/action.yaml
@@ -25,7 +25,7 @@ runs:
           ARCH="amd64"
         fi
         mkdir -p "$HOME"/.local/bin
-        curl -fsSL "$CODER_URL"/bin/coder-linux-${ARCH} -o "$HOME"/.local/bin/coder
+        curl -fsSL --compressed "$CODER_URL"/bin/coder-linux-${ARCH} -o "$HOME"/.local/bin/coder
         chmod +x "$HOME"/.local/bin/coder
         echo "$HOME/.local/bin" >> $GITHUB_PATH
         "$HOME"/.local/bin/coder version

--- a/action.yaml
+++ b/action.yaml
@@ -25,11 +25,13 @@ runs:
           ARCH="amd64"
         fi
         mkdir -p "$HOME"/.local/bin
-        curl -fsSL ${{ inputs.access_url }}/bin/coder-linux-${ARCH} -o $HOME/.local/bin/coder
-        chmod +x $HOME/.local/bin/coder
+        curl -fsSL "$CODER_URL"/bin/coder-linux-${ARCH} -o "$HOME"/.local/bin/coder
+        chmod +x "$HOME"/.local/bin/coder
         echo "$HOME/.local/bin" >> $GITHUB_PATH
-        $HOME/.local/bin/coder version
+        "$HOME"/.local/bin/coder version
       shell: bash
+      env:
+        CODER_URL: ${{ inputs.access_url }}
 
     - name: Login to Coder
       run: coder login --token $CODER_SESSION_TOKEN $CODER_URL

--- a/action.yaml
+++ b/action.yaml
@@ -17,11 +17,19 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Download Coder binary from access URL
-      run: curl -fsSL $CODER_URL/bin/coder-linux-amd64 -o /usr/local/bin/coder && chmod +x /usr/local/bin/coder
+    - name: Download and install Coder binary
+      run: |
+        if [ "${{ runner.arch }}" == "ARM64" ]; then
+          ARCH="arm64"
+        else
+          ARCH="amd64"
+        fi
+        mkdir -p $HOME/.local/bin
+        curl -fsSL ${{ inputs.access_url }}/bin/coder-linux-${ARCH} -o $HOME/.local/bin/coder
+        chmod +x $HOME/.local/bin/coder
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+        $HOME/.local/bin/coder version
       shell: bash
-      env:
-        CODER_URL: ${{ inputs.access_url }}
 
     - name: Login to Coder
       run: coder login --token $CODER_SESSION_TOKEN $CODER_URL

--- a/action.yaml
+++ b/action.yaml
@@ -24,7 +24,7 @@ runs:
         else
           ARCH="amd64"
         fi
-        mkdir -p $HOME/.local/bin
+        mkdir -p "$HOME"/.local/bin
         curl -fsSL ${{ inputs.access_url }}/bin/coder-linux-${ARCH} -o $HOME/.local/bin/coder
         chmod +x $HOME/.local/bin/coder
         echo "$HOME/.local/bin" >> $GITHUB_PATH


### PR DESCRIPTION
- add tests
- add arm64 support
- ensure binaries are installed in the local bin directory to support self-hosted runners without sudo or root access.

Closes #2